### PR TITLE
 BREAKING CHANGE: Hooks are now installed per-repo instead of globally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,13 @@ tmp/
 temp/
 *.tmp
 agentblame-chrome.zip
+
+# Agent Blame local database
+.agentblame/
+
+# Editor hook configs (created by agentblame init)
+.claude/
+.cursor/
+
+# Build artifacts
+packages/chrome/agentblame-chrome-*.zip

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentblame/chrome",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Agent Blame Chrome Extension - See AI attribution on GitHub PRs",
   "private": true,
   "scripts": {

--- a/packages/chrome/src/manifest.json
+++ b/packages/chrome/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Agent Blame",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "See AI-generated vs human-written code on GitHub PRs",
   "icons": {
     "16": "icons/icon16.png",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mesadev/agentblame",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "CLI to track AI-generated vs human-written code",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/src/lib/util.ts
+++ b/packages/cli/src/lib/util.ts
@@ -1,4 +1,5 @@
 import * as crypto from "node:crypto";
+import * as fs from "node:fs";
 import * as path from "node:path";
 
 /**
@@ -34,9 +35,27 @@ export function computeNormalizedHash(content: string): string {
 }
 
 /**
- * Get the agentblame directory path (~/.agentblame)
+ * Find the .agentblame directory by walking up from a file path.
+ * Returns null if not found (file is not in an initialized repo).
  */
-export function getAgentBlameDir(): string {
-  const home = process.env.HOME || process.env.USERPROFILE || "";
-  return `${home}/.agentblame`;
+export function findAgentBlameDir(filePath: string): string | null {
+  let dir = path.dirname(filePath);
+
+  while (dir !== path.dirname(dir)) {
+    const agentblameDir = path.join(dir, ".agentblame");
+    if (fs.existsSync(agentblameDir)) {
+      return agentblameDir;
+    }
+    dir = path.dirname(dir);
+  }
+
+  return null;
+}
+
+/**
+ * Get the agentblame directory for a specific repo root.
+ * Used during init when we know the repo root.
+ */
+export function getAgentBlameDirForRepo(repoRoot: string): string {
+  return path.join(repoRoot, ".agentblame");
 }

--- a/packages/cli/src/process.ts
+++ b/packages/cli/src/process.ts
@@ -11,6 +11,7 @@ import {
   getCommitMoves,
   buildMoveIndex,
   attachNote,
+  getAgentBlameDirForRepo,
   type RangeAttribution,
   type LineAttribution,
   type MatchResult,
@@ -20,6 +21,7 @@ import {
   markEditsAsMatched,
   findEditsByFile,
   getEditLines,
+  setAgentBlameDir,
 } from "./lib/database";
 
 // Terminal colors
@@ -229,6 +231,10 @@ export async function runProcess(sha?: string): Promise<void> {
     console.error("Error: Not in a git repository");
     process.exit(1);
   }
+
+  // Set up database directory for this repo
+  const agentblameDir = getAgentBlameDirForRepo(repoRoot);
+  setAgentBlameDir(agentblameDir);
 
   // Always resolve to actual SHA (not HEAD)
   let commitSha = sha || "HEAD";


### PR DESCRIPTION
  feat: repo-level hooks and database (v0.2.0)

  BREAKING CHANGE: Hooks are now installed per-repo instead of globally.
  Users must re-run `agentblame init` in each repo.

  Changes:
  - Hooks installed to .cursor/hooks.json and .claude/settings.json at repo level
  - Database stored in .agentblame/ per repo (auto-added to .gitignore)
  - Hook command uses `bunx @mesadev/agentblame capture` for portability
  - Added `agentblame capture` subcommand for hooks
  - Added `--force` flag to init/clean to remove old global installs
  - Renamed `uninstall` to `clean`

  New commands:
  - agentblame init --force  (setup + cleanup global)
  - agentblame clean         (remove hooks from repo)
  - agentblame clean --force (also cleanup global)