### PR TITLE
Add OpenCode support and fix attribution bugs

### DIFF
--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentblame/chrome",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Agent Blame Chrome Extension - See AI attribution on GitHub PRs",
   "private": true,
   "scripts": {

--- a/packages/chrome/src/content/content.css
+++ b/packages/chrome/src/content/content.css
@@ -2,7 +2,7 @@
 
 /* Attribution gutter colors */
 :root {
-  --ab-ai-color: var(--color-severe-fg, #f78166);      /* GitHub's coral orange */
+  --ab-ai-color: #b86540;      /* Mesa Orange */
 }
 
 /* Attribution gutter - box-shadow on the new line number cell */
@@ -24,7 +24,7 @@
   padding: 8px 16px;
   margin: 12px 0;
   background: var(--bgColor-default, var(--color-canvas-default, #ffffff));
-  border: 1px solid rgba(247, 129, 102, 0.25);
+  border: 1px solid rgba(184, 101, 64, 0.25);
   border-left: 3px solid var(--ab-ai-color);
   border-radius: 6px;
   font-size: 13px;
@@ -196,7 +196,7 @@
 @media (prefers-color-scheme: dark) {
   .ab-pr-summary {
     background: var(--bgColor-default, #0d1117);
-    border-color: rgba(247, 129, 102, 0.4);
+    border-color: rgba(184, 101, 64, 0.4);
     border-left-color: var(--ab-ai-color);
   }
 

--- a/packages/chrome/src/content/content.ts
+++ b/packages/chrome/src/content/content.ts
@@ -286,7 +286,6 @@ function findAttribution(
     filePath,
     filePath.replace(/^\//, ""),
     `/${filePath}`,
-    filePath.split("/").slice(-1)[0], // Just filename
   ];
 
   for (const variant of variants) {
@@ -294,6 +293,18 @@ function findAttribution(
     const variantMatch = map.get(variantKey);
     if (variantMatch) {
       return variantMatch;
+    }
+  }
+
+  // Last resort: match by filename only (for React UI which may only show filename)
+  // Search through the map for any key that ends with the same filename:lineNumber
+  const filename = filePath.split("/").pop() || filePath;
+  if (filename && filename !== filePath) {
+    for (const [mapKey, value] of map.entries()) {
+      // mapKey format is "path/to/file.ext:lineNumber"
+      if (mapKey.endsWith(`/${filename}:${lineNumber}`) || mapKey === `${filename}:${lineNumber}`) {
+        return value;
+      }
     }
   }
 

--- a/packages/chrome/src/lib/mock-analytics.ts
+++ b/packages/chrome/src/lib/mock-analytics.ts
@@ -114,6 +114,23 @@ async function setCachedAnalytics(owner: string, repo: string, data: AnalyticsDa
 }
 
 /**
+ * Clear cached analytics for a repository
+ */
+export async function clearAnalyticsCache(owner: string, repo: string): Promise<void> {
+  const cacheKey = `analytics_${owner}_${repo}`;
+
+  // Clear memory cache
+  memoryCache.delete(cacheKey);
+
+  // Clear storage cache
+  try {
+    await chrome.storage.local.remove(cacheKey);
+  } catch {
+    // Storage access failed, memory cache still cleared
+  }
+}
+
+/**
  * Mock analytics data for UI development
  */
 export const MOCK_ANALYTICS: AnalyticsData = {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mesadev/agentblame",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "CLI to track AI-generated vs human-written code",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/src/blame.ts
+++ b/packages/cli/src/blame.ts
@@ -24,7 +24,7 @@ const c = {
   cyan: "\x1b[36m",
   yellow: "\x1b[33m",
   green: "\x1b[32m",
-  orange: "\x1b[38;5;166m", // Mesa Orange - matches gutter color
+  orange: "\x1b[38;2;184;101;64m", // Soft Mesa Orange #b86540
   blue: "\x1b[34m",
   gray: "\x1b[90m",
 };
@@ -152,7 +152,7 @@ function outputFormatted(lines: LineAttribution[], filePath: string): void {
     let attrInfo = "";
     let visibleLen = 0;
     if (attribution) {
-      const provider = attribution.provider === "cursor" ? "Cursor" : "Claude";
+      const provider = attribution.provider === "cursor" ? "Cursor" : attribution.provider === "opencode" ? "OpenCode" : "Claude";
       const model = attribution.model && attribution.model !== "claude" ? attribution.model : "";
       const label = model ? `${provider} - ${model}` : provider;
       visibleLen = label.length + 3; // +2 for emoji (renders 2-wide) + 1 space

--- a/packages/cli/src/lib/types.ts
+++ b/packages/cli/src/lib/types.ts
@@ -11,7 +11,7 @@
 /**
  * AI provider that generated the code
  */
-export type AiProvider = "cursor" | "claudeCode";
+export type AiProvider = "cursor" | "claudeCode" | "opencode";
 
 /**
  * Attribution category - we only track AI-generated code
@@ -178,6 +178,7 @@ export interface GitState {
 export interface ProviderBreakdown {
   cursor?: number;
   claudeCode?: number;
+  opencode?: number;
 }
 
 /**

--- a/packages/cli/src/process.ts
+++ b/packages/cli/src/process.ts
@@ -33,7 +33,7 @@ const c = {
   cyan: "\x1b[36m",
   yellow: "\x1b[33m",
   green: "\x1b[32m",
-  orange: "\x1b[38;5;166m", // Mesa Orange - matches gutter color
+  orange: "\x1b[38;2;184;101;64m", // Soft Mesa Orange #b86540
   blue: "\x1b[34m",
 };
 
@@ -289,7 +289,7 @@ export async function runProcess(sha?: string): Promise<void> {
     console.log(`${border}${padRight(aiHeader, aiHeader.length)}${border}`);
 
     for (const attr of result.attributions) {
-      const provider = attr.provider === "cursor" ? "Cursor" : "Claude";
+      const provider = attr.provider === "cursor" ? "Cursor" : attr.provider === "opencode" ? "OpenCode" : "Claude";
       const model = attr.model && attr.model !== "claude" ? attr.model : "";
       const modelStr = model ? ` - ${model}` : "";
       const visibleText = `    ${attr.path}:${attr.startLine}-${attr.endLine} [${provider}${modelStr}]`;


### PR DESCRIPTION
  Add OpenCode support and fix attribution bugs                                                                                                                                                                                          
                                                                                                                                                                                                                                         
  Features:                                                                                                                                                                                                                              
  - Add OpenCode provider support with plugin-based hooks                                                                                                                                                                                
  - Add refresh button to analytics page to bypass cache                                                                                                                                                                                 
  - Improve model name formatting (claude-opus-4-5-20251101 → Claude Opus 4.5)                                                                                                                                                           
                                                                                                                                                                                                                                         
  Bug fixes:                                                                                                                                                                                                                             
  - Fix Cursor edits being attributed to Claude (skip cursor_version payloads)                                                                                                                                                           
  - Fix Chrome plugin for GitHub's React UI (table-based containers)                                                                                                                                                                     
  - Fix provider display showing "Claude" instead of "OpenCode"                                                                                                                                                                          
                                                                                                                                                                                                                                         
  UI:                                                                                                                                                                                                                                    
  - Update AI color to soft mesa orange (#b86540)                                                                                                                                                                                        
  - Soften tool color palette for analytics charts                                                                                                                                                                                       
                                                                                                                                                                                                                                         
  Versions: CLI 0.2.7, Chrome 0.2.8