### PR TITLE
Move push notes outside of transfer conditional

### DIFF
--- a/packages/cli/src/sync.ts
+++ b/packages/cli/src/sync.ts
@@ -559,10 +559,9 @@ export async function sync(options: SyncOptions = {}): Promise<void> {
     console.log(
       `\nSummary: Transferred ${totalTransferred} attribution(s) for ${successCount} merge(s)`,
     );
-
-    // Push notes
-    pushNotes(repoRoot, options);
   } else {
     console.log("\nNo attributions were transferred.");
   }
+
+  pushNotes(repoRoot, options);
 }


### PR DESCRIPTION
I am pretty sure pushNotes was erroneously scooped up into the conditional. Had to move it out to actually get it to push agentblame notes to my own repo.

(No attribution on this PR, because it's 100% human ;) )