### PR TITLE
New Version update for firefox and chrome

### DIFF
--- a/packages/chrome/manifest.json
+++ b/packages/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Agent Blame",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "See AI-generated vs human-written code on GitHub PRs",
   "icons": {
     "16": "icons/icon16.png",

--- a/packages/extension/src/popup/popup.html
+++ b/packages/extension/src/popup/popup.html
@@ -90,7 +90,7 @@
 
     <footer>
       <a href="https://github.com/mesa-dot-dev/agentblame" target="_blank">Documentation</a>
-      <span class="version">v3.1.0</span>
+      <span class="version" id="version"></span>
     </footer>
   </div>
 

--- a/packages/extension/src/popup/popup.ts
+++ b/packages/extension/src/popup/popup.ts
@@ -280,5 +280,11 @@ tokenInput.addEventListener("focus", () => {
 // Log popup opened
 logInfo("popup", "Popup opened");
 
+// Set version from manifest
+const versionEl = document.getElementById("version");
+if (versionEl) {
+  versionEl.textContent = `v${api.runtime.getManifest().version}`;
+}
+
 // Initialize on load
 init();

--- a/packages/firefox/manifest.json
+++ b/packages/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Agent Blame",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "See AI-generated vs human-written code on GitHub PRs",
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
 Fix Cursor hook stdin bug, enable prompt capture by default                                                                                                                                                                            
  - Enable prompt capture by default: `storePromptContent` now defaults to
    true. Users can disable with `agentblame config storePromptContent false`
  - Fix extension version display: Read version from manifest dynamically
    instead of hardcoding in popup.html
  - Bump CLI to 3.1.3, Chrome/Firefox extensions to 3.1.1